### PR TITLE
Add news parser tests using feedparser stubs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+import json
+from types import ModuleType, SimpleNamespace
+
+# Provide a lightweight stub for `jose.jwt` if the real library is unavailable.
+if 'jose' not in sys.modules:
+    jose_module = ModuleType('jose')
+    def _encode(data, key, algorithm=None):
+        processed = {
+            k: (int(v.timestamp()) if hasattr(v, "timestamp") else v)
+            for k, v in data.items()
+        }
+        return json.dumps(processed)
+
+    def _decode(token, key, algorithms=None):
+        return json.loads(token)
+
+    jwt_ns = SimpleNamespace(encode=_encode, decode=_decode)
+    jose_module.jwt = jwt_ns
+    sys.modules['jose'] = jose_module
+    sys.modules['jose.jwt'] = jwt_ns
+
+# Minimal stub for `passlib.context.CryptContext` if `passlib` isn't available.
+if 'passlib.context' not in sys.modules:
+    passlib_context_module = ModuleType('passlib.context')
+
+    class DummyCryptContext:
+        def __init__(self, schemes=None, deprecated='auto'):
+            pass
+
+        def hash(self, password: str) -> str:
+            return 'hashed-' + password
+
+        def verify(self, plain_password: str, hashed_password: str) -> bool:
+            return self.hash(plain_password) == hashed_password
+
+    passlib_context_module.CryptContext = DummyCryptContext
+
+    # Ensure "passlib" package exists and exposes the context module
+    passlib_pkg = sys.modules.setdefault('passlib', ModuleType('passlib'))
+    passlib_pkg.context = passlib_context_module
+    sys.modules['passlib.context'] = passlib_context_module

--- a/tests/test_news_parser.py
+++ b/tests/test_news_parser.py
@@ -1,0 +1,78 @@
+import sys
+import time
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+
+
+class Entry(SimpleNamespace):
+    def __contains__(self, item):
+        return hasattr(self, item)
+
+import pytest
+import asyncio
+
+# Prepare a minimal stub for the `feedparser` module so that project modules can
+# import it even if the real package is absent.
+feedparser_stub = sys.modules.setdefault("feedparser", SimpleNamespace())
+
+from app.parsers.news_parser import parse_news
+from app.parsers.sync_news_parser import parse_news_sync
+from app.schemas.news import NewsCreate
+
+MOCK_RSS = """<?xml version='1.0' encoding='UTF-8'?>
+<rss version='2.0'>
+<channel>
+    <title>Mock Feed</title>
+    <item>
+        <title>Item 1</title>
+        <link>http://example.com/1</link>
+        <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+        <title>Item 2</title>
+        <link>http://example.com/2</link>
+        <pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+</channel>
+</rss>"""
+
+
+def _build_parsed(feed: str):
+    root = ET.fromstring(feed)
+    entries = []
+    for item in root.findall(".//item"):
+        entries.append(
+            Entry(
+                title=item.findtext("title"),
+                link=item.findtext("link"),
+                published_parsed=time.strptime(
+                    item.findtext("pubDate"), "%a, %d %b %Y %H:%M:%S %Z"
+                ),
+            )
+        )
+    return SimpleNamespace(entries=entries)
+
+
+mock_parsed_feed = _build_parsed(MOCK_RSS)
+
+
+def test_parse_news(monkeypatch):
+    monkeypatch.setattr(feedparser_stub, "parse", lambda url: mock_parsed_feed, raising=False)
+    result = asyncio.run(parse_news(1, "dummy"))
+
+    assert len(result) == 2
+    assert all(isinstance(item, NewsCreate) for item in result)
+    assert [n.title for n in result] == ["Item 1", "Item 2"]
+    assert [n.url for n in result] == ["http://example.com/1", "http://example.com/2"]
+    assert all(n.source_id == 1 for n in result)
+
+
+def test_parse_news_sync(monkeypatch):
+    monkeypatch.setattr(feedparser_stub, "parse", lambda url: mock_parsed_feed, raising=False)
+    result = parse_news_sync(2, "dummy")
+
+    assert len(result) == 2
+    assert all(isinstance(item, NewsCreate) for item in result)
+    assert [n.title for n in result] == ["Item 1", "Item 2"]
+    assert [n.url for n in result] == ["http://example.com/1", "http://example.com/2"]
+    assert all(n.source_id == 2 for n in result)


### PR DESCRIPTION
## Summary
- add a `conftest.py` with lightweight stubs for `jose.jwt` and `passlib.context`
- add new tests for async and sync news parsers using a mocked RSS feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596c083024832c9e08cd2a7f48c8e6