### PR TITLE
Add async SQLite CRUD tests

### DIFF
--- a/tests/test_crud_news.py
+++ b/tests/test_crud_news.py
@@ -1,0 +1,47 @@
+import datetime
+import pytest
+
+from app.crud.news import NewsCRUD
+from app.crud.source import SourceCRUD
+from app.schemas.news import NewsCreate
+from app.schemas.source import SourceCreate
+
+
+@pytest.mark.asyncio
+async def test_news_crud(async_session):
+    source = await SourceCRUD().create(
+        SourceCreate(title="Src", url="http://s.com", rss_url="http://s.com/rss"),
+        async_session,
+    )
+
+    crud = NewsCRUD()
+    create_data = NewsCreate(
+        title="Title",
+        url="http://s.com/n1",
+        published_at=datetime.datetime.now(datetime.timezone.utc),
+        source_id=source.id,
+    )
+    news = await crud.create(create_data, async_session)
+    assert news.id is not None
+
+    all_news = await crud.get_all(async_session)
+    assert len(all_news) == 1
+    assert all_news[0].id == news.id
+
+    fetched = await crud.get_by_id(news.id, async_session)
+    assert fetched.title == "Title"
+
+    updated = await crud.update(
+        fetched,
+        NewsCreate(
+            title="Updated",
+            url="http://s.com/n2",
+            published_at=create_data.published_at,
+            source_id=source.id,
+        ),
+        async_session,
+    )
+    assert updated.title == "Updated"
+
+    await crud.delete(updated, async_session)
+    assert await crud.get_by_id(news.id, async_session) is None

--- a/tests/test_crud_source.py
+++ b/tests/test_crud_source.py
@@ -1,0 +1,32 @@
+import pytest
+from app.crud.source import SourceCRUD
+from app.schemas.source import SourceCreate, SourceUpdate
+
+
+@pytest.mark.asyncio
+async def test_source_crud(async_session):
+    crud = SourceCRUD()
+    create_data = SourceCreate(
+        title="Example",
+        url="http://example.com",
+        rss_url="http://example.com/rss",
+    )
+    source = await crud.create(create_data, async_session)
+    assert source.id is not None
+
+    all_sources = await crud.get(async_session)
+    assert len(all_sources) == 1
+    assert all_sources[0].id == source.id
+
+    fetched = await crud.get_by_id(source.id, async_session)
+    assert fetched.title == "Example"
+
+    updated = await crud.update(
+        fetched,
+        SourceUpdate(title="Updated title"),
+        async_session,
+    )
+    assert updated.title == "Updated title"
+
+    await crud.delete(updated, async_session)
+    assert await crud.get_by_id(source.id, async_session) is None

--- a/tests/test_crud_users.py
+++ b/tests/test_crud_users.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.crud.users import UserCRUD
+from app.schemas.users import UserCreate
+
+
+@pytest.mark.asyncio
+async def test_user_crud(async_session):
+    crud = UserCRUD()
+    create_data = UserCreate(
+        email="user@example.com",
+        username="user",
+        password="secret",
+    )
+    user = await crud.create(create_data, async_session)
+    assert user.id is not None
+
+    by_username = await crud.get_by_username("user", async_session)
+    assert by_username is not None
+    assert by_username.email == "user@example.com"
+
+    by_email = await crud.get_by_email("user@example.com", async_session)
+    assert by_email is not None
+    assert by_email.username == "user"


### PR DESCRIPTION
## Summary
- create async test session with in-memory SQLite
- add CRUD tests for sources, news, and users

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68596d209e50832cb246904cb3373029