### PR TITLE
Add tests for API endpoints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,112 @@ if 'passlib.context' not in sys.modules:
     passlib_pkg.context = passlib_context_module
     sys.modules['passlib.context'] = passlib_context_module
 
+# Provide a lightweight stub for the `httpx` library if it's unavailable.
+if 'httpx' not in sys.modules:
+    httpx_module = ModuleType('httpx')
+
+    class ByteStream:
+        def __init__(self, content: bytes):
+            self._content = content
+
+        def read(self) -> bytes:
+            return self._content
+
+    class Request:
+        def __init__(self, method: str, url: str, headers=None, stream=None):
+            self.method = method
+            self.url = SimpleNamespace(
+                scheme=url.split('://')[0],
+                netloc=url.split('://')[1].split('/')[0].encode(),
+                path='/' + '/'.join(url.split('://')[1].split('/')[1:]),
+                raw_path=('/' + '/'.join(url.split('://')[1].split('/')[1:])).encode(),
+                query=b"",
+            )
+            self.headers = headers or {}
+            self._stream = stream or ByteStream(b"")
+
+        def read(self):
+            return self._stream.read()
+
+    class Response:
+        def __init__(self, status_code: int, headers=None, stream=None, request=None):
+            self.status_code = status_code
+            self.headers = headers or []
+            self._stream = stream or ByteStream(b"")
+            self.request = request
+
+        def json(self):
+            import json as _json
+            return _json.loads(self._stream.read().decode())
+
+    class BaseTransport:
+        def handle_request(self, request: Request) -> Response:  # pragma: no cover - stub
+            raise NotImplementedError
+
+    class Client:
+        def __init__(self, *, app=None, base_url: str = "", headers=None, transport=None, follow_redirects=True, cookies=None):
+            self.app = app
+            self.base_url = base_url
+            self.headers = headers or {}
+            self.transport = transport
+
+        def request(self, method: str, url: str, **kwargs) -> Response:
+            url = self.base_url.rstrip('/') + '/' + url.lstrip('/')
+            headers = kwargs.get('headers', {})
+            stream = ByteStream(kwargs.get('content', b""))
+            req = Request(method, url, headers=headers, stream=stream)
+            return self.transport.handle_request(req)
+
+        def get(self, url: str, **kwargs) -> Response:
+            return self.request('GET', url, **kwargs)
+
+        def post(self, url: str, **kwargs) -> Response:
+            return self.request('POST', url, **kwargs)
+
+    _client_module = ModuleType('httpx._client')
+    _client_module.USE_CLIENT_DEFAULT = object()
+    sys.modules['httpx._client'] = _client_module
+
+    httpx_module.Client = Client
+    httpx_module.BaseTransport = BaseTransport
+    httpx_module.Request = Request
+    httpx_module.Response = Response
+    httpx_module.ByteStream = ByteStream
+    sys.modules['httpx'] = httpx_module
+
+# Provide a minimal stub for SQLAlchemy so imports succeed when the real
+# package isn't installed. This allows tests to skip gracefully.
+if 'sqlalchemy' not in sys.modules:
+    sa_module = ModuleType('sqlalchemy')
+    sa_module.ext = ModuleType('sqlalchemy.ext')
+    sa_asyncio = ModuleType('sqlalchemy.ext.asyncio')
+    sa_asyncio.create_async_engine = None
+    sa_asyncio.async_sessionmaker = None
+    sa_asyncio.AsyncSession = type('AsyncSession', (), {})
+    sa_module.ext.asyncio = sa_asyncio
+    sys.modules['sqlalchemy.ext'] = sa_module.ext
+    sys.modules['sqlalchemy.ext.asyncio'] = sa_asyncio
+
+    sa_future = ModuleType('sqlalchemy.future')
+    sa_future.select = lambda *a, **k: None
+    sa_module.future = sa_future
+    sys.modules['sqlalchemy.future'] = sa_future
+
+    sa_orm = ModuleType('sqlalchemy.orm')
+    sa_orm.DeclarativeBase = type('DeclarativeBase', (), {})
+    sa_orm.relationship = lambda *a, **k: None
+    sa_module.orm = sa_orm
+    sys.modules['sqlalchemy.orm'] = sa_orm
+
+    def _column(*args, **kwargs):
+        return None
+
+    sa_module.Column = _column
+    for name in ['Integer', 'String', 'DateTime', 'Boolean', 'ForeignKey']:
+        setattr(sa_module, name, type(name, (), {}))
+
+    sys.modules['sqlalchemy'] = sa_module
+
 import pytest
 
 try:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,112 @@
+import os
+import datetime
+import pytest
+from fastapi.testclient import TestClient
+
+# ensure database URL for app import
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from app.main import app
+from app.db.session import get_async_session
+
+
+@pytest.fixture()
+async def client(async_session):
+    async def override_session():
+        yield async_session
+    app.dependency_overrides[get_async_session] = override_session
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_sources_endpoints(client):
+    create_data = {
+        "title": "Example",
+        "url": "http://example.com",
+        "rss_url": "http://example.com/rss",
+    }
+    resp = client.post("/api/v1/sources/", json=create_data)
+    assert resp.status_code == 200
+    src = resp.json()
+    assert src["id"]
+    src_id = src["id"]
+
+    resp = client.get(f"/api/v1/sources/{src_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == src_id
+
+    resp = client.get("/api/v1/sources/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.get("/api/v1/sources/999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_news_endpoints(client):
+    src_resp = client.post(
+        "/api/v1/sources/",
+        json={"title": "Src", "url": "http://s.com", "rss_url": "http://s.com/rss"},
+    )
+    src_id = src_resp.json()["id"]
+
+    news_data = {
+        "title": "News1",
+        "url": "http://s.com/n1",
+        "published_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "source_id": src_id,
+    }
+    resp = client.post("/api/v1/news/", json=news_data)
+    assert resp.status_code == 201
+    news = resp.json()
+    news_id = news["id"]
+
+    resp = client.get(f"/api/v1/news/{news_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == news_id
+
+    resp = client.get("/api/v1/news/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.get("/api/v1/news/999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_auth_and_user_me(client):
+    user_data = {
+        "email": "user@example.com",
+        "username": "user",
+        "password": "secret",
+    }
+    resp = client.post("/api/v1/auth/register", json=user_data)
+    assert resp.status_code == 200
+    user = resp.json()
+    assert user["email"] == user_data["email"]
+
+    dup_resp = client.post("/api/v1/auth/register", json=user_data)
+    assert dup_resp.status_code == 400
+
+    login_resp = client.post(
+        "/api/v1/auth/login",
+        data={"username": "user", "password": "secret"},
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+
+    wrong_resp = client.post(
+        "/api/v1/auth/login",
+        data={"username": "user", "password": "wrong"},
+    )
+    assert wrong_resp.status_code == 400
+
+    me_resp = client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert me_resp.status_code == 200
+    assert me_resp.json()["username"] == "user"


### PR DESCRIPTION
## Summary
- add HTTP API tests using TestClient
- stub `httpx` and `sqlalchemy` so the app can be imported without real deps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68596e9cf678832ca6fd0af29be51fbe