### PR TITLE
Fix sync_session_maker parameter typo

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -25,7 +25,7 @@ sync_engine = create_engine(
 )
 
 sync_session_maker = sessionmaker(
-    bin=sync_engine,
+    bind=sync_engine,
     autoflush=False,
     autocommit=False
 )


### PR DESCRIPTION
## Summary
- fix typo in sync_session_maker configuration

## Testing
- `pytest -q` *(fails: email-validator not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bb06cb95c832cb50a2b57f4c52257