### PR TITLE
Remove duplicate is_active definition

### DIFF
--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -12,7 +12,6 @@ class UserRead(BaseModel):
     email: EmailStr
     username: str
     is_active: bool
-    is_active: bool
 
     model_config = {
         "from_attributes": True


### PR DESCRIPTION
## Summary
- clean up `UserRead` schema by deleting the duplicated `is_active` attribute

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb0dc9660832c897c82eed94e245a