### PR TITLE
Fix parameter names in create_access_token

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -19,9 +19,9 @@ def get_password_hash(password):
     return pwd_context.hash(password)
 
 
-def create_access_token(data: dict, expides_delta: timedelta | None = None):
-    to_encode_date = data.copy()
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode_data = data.copy()
     expired_time = (datetime.now(timezone.utc) +
-                    (expides_delta or timedelta(minutes=15)))
-    to_encode_date.update({"exp": expired_time})
-    return jwt.encode(to_encode_date, SECRET_KEY, algorithm=ALGORITHM)
+                    (expires_delta or timedelta(minutes=15)))
+    to_encode_data.update({"exp": expired_time})
+    return jwt.encode(to_encode_data, SECRET_KEY, algorithm=ALGORITHM)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,7 +23,7 @@ def test_get_password_hash_and_verify_password():
 
 def test_create_access_token_contains_claims():
     data = {"sub": "tester"}
-    token = create_access_token(data=data, expides_delta=timedelta(minutes=5))
+    token = create_access_token(data=data, expires_delta=timedelta(minutes=5))
 
     decoded = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
 


### PR DESCRIPTION
## Summary
- rename `expides_delta` parameter to `expires_delta`
- rename `to_encode_date` variable to `to_encode_data`
- update test to use renamed parameter

## Testing
- `pytest -q` *(fails: httpx, sqlalchemy, pydantic dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bb0f2a9b8832cb13a8de7ea9e4e9e