### PR TITLE
Fix variable typo

### DIFF
--- a/app/api/v1/news.py
+++ b/app/api/v1/news.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import logging
 
 from app.db.session import get_async_session
-from app.crud.news import news_crude
+from app.crud.news import news_crud
 from app.schemas.news import NewsCreate, NewsRead, NewsUpdate
 
 router = APIRouter(prefix="/news", tags=["News"])
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @router.get("/", response_model=List[NewsRead])
 async def get_all_news(session: AsyncSession = Depends(get_async_session)):
     logger.debug("Fetching all news")
-    return await news_crude.get_all(session)
+    return await news_crud.get_all(session)
 
 
 @router.get("/{news_id}", response_model=NewsRead)
@@ -24,7 +24,7 @@ async def get_news_by_id(
     news_id: int,
     session: AsyncSession = Depends(get_async_session)
 ):
-    news = await news_crude.get_by_id(news_id, session)
+    news = await news_crud.get_by_id(news_id, session)
     if not news:
         raise HTTPException(status_code=404, detail="News not found")
     logger.debug("Returning news %s", news_id)
@@ -37,7 +37,7 @@ async def create_news(
     session: AsyncSession = Depends(get_async_session)
 ):
     logger.info("Creating news %s", news.url)
-    return await news_crude.create(news, session)
+    return await news_crud.create(news, session)
 
 
 @router.put("/{news_id}", response_model=NewsUpdate)
@@ -46,11 +46,11 @@ async def update_news(
     news_data: NewsUpdate,
     session: AsyncSession = Depends(get_async_session)
 ):
-    news = await news_crude.get_by_id(news_id, session)
+    news = await news_crud.get_by_id(news_id, session)
     if not news:
         raise HTTPException(status_code=404, detail="News not found")
     logger.info("Updating news %s", news_id)
-    return await news_crude.update(news, news_data, session)
+    return await news_crud.update(news, news_data, session)
 
 
 @router.delete("/{news_id}", status_code=204)
@@ -58,10 +58,10 @@ async def delete_news(
     news_id: int,
     session: AsyncSession = Depends(get_async_session)
 ):
-    news = await news_crude.get_by_id(news_id, session)
+    news = await news_crud.get_by_id(news_id, session)
     if not news:
         raise HTTPException(status_code=404, detail="News not found")
-    await news_crude.delete(news, session)
+    await news_crud.delete(news, session)
     logger.info("Deleted news %s", news_id)
     return HTTPException(status_code=204, detail="Source deleted")
 

--- a/app/api/v1/source.py
+++ b/app/api/v1/source.py
@@ -4,7 +4,7 @@ import logging
 
 from app.db.session import get_async_session
 from app.crud.source import source_crud
-from app.crud.news import news_crude
+from app.crud.news import news_crud
 from app.parsers.news_parser import parse_news
 from app.schemas.news import NewsRead
 from app.schemas.source import SourceCreate, SourceRead, SourceUpdate
@@ -79,7 +79,7 @@ async def parse_source(
 
     created_news = []
     for item in news_items:
-        created = await news_crude.create(item, session)
+        created = await news_crud.create(item, session)
         logger.debug("Created news from parse %s", created.id)
         created_news.append(created)
 

--- a/app/crud/news.py
+++ b/app/crud/news.py
@@ -65,5 +65,5 @@ class NewsCRUD:
         logger.debug("Deleted news %s", news.id)
 
 
-news_crude = NewsCRUD()
+news_crud = NewsCRUD()
 


### PR DESCRIPTION
## Summary
- correct `news_crude` typo by renaming to `news_crud`
- adjust API modules to use the new name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686bb10549b4832cb828697b3a361b06