### PR TITLE
Fix delete parameter name

### DIFF
--- a/app/crud/sync_news.py
+++ b/app/crud/sync_news.py
@@ -39,7 +39,7 @@ class NewsSyncCRUD:
         logger.debug("Updated news %s", news.id)
         return news
 
-    def delete(sels, news: News, session: Session) -> None:
+    def delete(self, news: News, session: Session) -> None:
         session.delete(news)
         session.commit()
         logger.debug("Deleted news %s", news.id)


### PR DESCRIPTION
## Summary
- fix the `delete` method signature in `NewsSyncCRUD`

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1012384832c8a5434731cf2c2cf