### PR TITLE
Fix annotation in NewsCRUD update

### DIFF
--- a/app/crud/news.py
+++ b/app/crud/news.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.models.news import News
-from app.schemas.news import NewsCreate
+from app.schemas.news import NewsCreate, NewsUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class NewsCRUD:
     async def update(
         self,
         news: News,
-        news_data: NewsCreate,
+        news_data: NewsUpdate,
         session: AsyncSession
     ) -> News:
         news.title = news_data.title

--- a/tests/test_crud_news.py
+++ b/tests/test_crud_news.py
@@ -3,7 +3,7 @@ import pytest
 
 from app.crud.news import NewsCRUD
 from app.crud.source import SourceCRUD
-from app.schemas.news import NewsCreate
+from app.schemas.news import NewsCreate, NewsUpdate
 from app.schemas.source import SourceCreate
 
 
@@ -33,7 +33,7 @@ async def test_news_crud(async_session):
 
     updated = await crud.update(
         fetched,
-        NewsCreate(
+        NewsUpdate(
             title="Updated",
             url="http://s.com/n2",
             published_at=create_data.published_at,


### PR DESCRIPTION
## Summary
- allow partial updates by annotating `news_data` as `NewsUpdate`
- reflect new schema in CRUD tests

## Testing
- `pytest -q` *(fails: httpx attribute error, SQLAlchemy import error, Pydantic missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb10b4fe0832c9d3429e15adae530