### PR TITLE
Fix timezone import in parser

### DIFF
--- a/app/parsers/sync_news_parser.py
+++ b/app/parsers/sync_news_parser.py
@@ -1,5 +1,5 @@
 import feedparser
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 from app.schemas.news import NewsCreate
@@ -14,7 +14,7 @@ def parse_news_sync(source_id: int, rss_url: str) -> list[NewsCreate]:
         published_at = (
             datetime(*entry.published_parsed[:6])
             if "published_parsed" in entry
-            else datetime.now(datetime.timezone.utc)
+            else datetime.now(timezone.utc)
         )
         news.append(
             NewsCreate(


### PR DESCRIPTION
## Summary
- import `timezone` in `sync_news_parser`
- use `timezone.utc` when generating timestamp

## Testing
- `pytest -q` *(fails: module 'httpx' has no attribute '_client' and other missing dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9a7afb0832caf181cbf2203f3eb