### PR TITLE
Fix OAuth2 tokenUrl path

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 logger = logging.getLogger(__name__)
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
 
 @router.get("/items/")


### PR DESCRIPTION
## Summary
- update OAuth2 token URL to `/api/v1/auth/login`

## Testing
- `python3.12 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9d455ec832c97faf6a4bf1e0209