### PR TITLE
Fix news update response type

### DIFF
--- a/app/api/v1/news.py
+++ b/app/api/v1/news.py
@@ -40,7 +40,7 @@ async def create_news(
     return await news_crud.create(news, session)
 
 
-@router.put("/{news_id}", response_model=NewsUpdate)
+@router.put("/{news_id}", response_model=NewsRead)
 async def update_news(
     news_id: int,
     news_data: NewsUpdate,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,11 @@ if 'httpx' not in sys.modules:
     _client_module.USE_CLIENT_DEFAULT = object()
     sys.modules['httpx._client'] = _client_module
 
+    # Expose the submodule as an attribute so type hints referencing
+    # ``httpx._client`` work as expected.
+    httpx_module._client = _client_module
+    httpx_module.__path__ = []
+
     httpx_module.Client = Client
     httpx_module.BaseTransport = BaseTransport
     httpx_module.Request = Request

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -75,6 +75,16 @@ async def test_news_endpoints(client):
     resp = client.get("/api/v1/news/999")
     assert resp.status_code == 404
 
+    update_data = {
+        "title": "Updated",
+        "url": "http://s.com/n2",
+        "published_at": news_data["published_at"],
+        "source_id": src_id,
+    }
+    put_resp = client.put(f"/api/v1/news/{news_id}", json=update_data)
+    assert put_resp.status_code == 200
+    assert put_resp.json()["title"] == "Updated"
+
 
 @pytest.mark.asyncio
 async def test_auth_and_user_me(client):


### PR DESCRIPTION
## Summary
- return `NewsRead` from PUT /news
- expose `httpx._client` attribute for stubs
- test updating news via API

## Testing
- `pytest -q` *(fails: module 'httpx._client' has no attribute 'CookieTypes' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9e1924c832ca3a25aa5705e7056