### PR TITLE
Switch to pip-based setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,13 +100,6 @@ ipython_config.py
 #   commonly ignored for libraries.
 #uv.lock
 
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-poetry.lock
-.poetry
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ```bash
 git clone git@github.com:NumiViX/FeedHound.git
 cd feedhound
-poetry install
+pip install -r requirements.txt
 cp .env.example .env
 ```
 
@@ -38,10 +38,10 @@ docker-compose up -d
 alembic upgrade head
 
 # 3. Запуск FastAPI сервера
-poetry run uvicorn app.main:app --reload
+uvicorn app.main:app --reload
 
 # 4. Запуск Celery воркера
-poetry run celery -A app.core.celery_app.celery worker --loglevel=info
+celery -A app.core.celery_app.celery worker --loglevel=info
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,38 +3,10 @@ name = "feedhound"
 version = "0.1.0"
 description = ""
 authors = [
-    {name = "NumiViX",email = "yakhin.v.r@yandex.ru"}
+    {name = "NumiViX", email = "yakhin.v.r@yandex.ru"}
 ]
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "fastapi[all] (>=0.115.12,<0.116.0)",
-    "sqlalchemy[asyncio] (>=2.0.40,<3.0.0)",
-    "asyncpg (>=0.30.0,<0.31.0)",
-    "pydantic (>=2.11.4,<3.0.0)",
-    "aiohttp (>=3.11.18,<4.0.0)",
-    "feedparser (>=6.0.11,<7.0.0)",
-    "python-dotenv (>=1.1.0,<2.0.0)",
-    "redis (>=4.5.4,<5.0.0)",
-    "celery[redis] (>=5.5.2,<6.0.0)",
-    "alembic (>=1.15.2,<2.0.0)",
-    "psycopg2-binary (>=2.9.10,<3.0.0)",
-    "pydantic-settings (>=2.9.1,<3.0.0)",
-    "python-jose[cryptography] (>=3.4.0,<4.0.0)",
-    "passlib[bcrypt] (>=1.7.4,<2.0.0)"
-]
-
-
-[project.optional-dependencies]
-dev = [
-    "pytest",
-    "pytest-asyncio",
-    "httpx",
-]
-
-[build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "-ra"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+fastapi[all]>=0.115.12,<0.116.0
+sqlalchemy[asyncio]>=2.0.40,<3.0.0
+asyncpg>=0.30.0,<0.31.0
+pydantic>=2.11.4,<3.0.0
+aiohttp>=3.11.18,<4.0.0
+feedparser>=6.0.11,<7.0.0
+python-dotenv>=1.1.0,<2.0.0
+redis>=4.5.4,<5.0.0
+celery[redis]>=5.5.2,<6.0.0
+alembic>=1.15.2,<2.0.0
+psycopg2-binary>=2.9.10,<3.0.0
+pydantic-settings>=2.9.1,<3.0.0
+python-jose[cryptography]>=3.4.0,<4.0.0
+passlib[bcrypt]>=1.7.4,<2.0.0


### PR DESCRIPTION
## Summary
- replace Poetry config with requirements files
- document pip usage in README
- drop Poetry ignores

## Testing
- `pytest -q` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bbd5e5f00832c8ddf7c5caf79f2af